### PR TITLE
Correct column name generation

### DIFF
--- a/examples/src/main/kotlin/rocks/frieler/kraftsql/h2/expressions/ArrayConcatenation.kt
+++ b/examples/src/main/kotlin/rocks/frieler/kraftsql/h2/expressions/ArrayConcatenation.kt
@@ -4,12 +4,10 @@ import rocks.frieler.kraftsql.expressions.Expression
 import rocks.frieler.kraftsql.h2.engine.H2Engine
 
 class ArrayConcatenation<T>(
-    private val left: Expression<H2Engine, Array<T>?>,
-    private val right: Expression<H2Engine, Array<T>?>,
+    val left: Expression<H2Engine, Array<T>?>,
+    val right: Expression<H2Engine, Array<T>?>,
 ) : rocks.frieler.kraftsql.expressions.ArrayConcatenation<H2Engine, T>(arrayOf(left, right)) {
     override fun sql() = "(${left.sql()}) || (${right.sql()})"
-
-    override fun defaultColumnName() = "${left.defaultColumnName()} || ${right.defaultColumnName()}"
 }
 
 @Suppress("DANGEROUS_CHARACTERS")

--- a/examples/src/main/kotlin/rocks/frieler/kraftsql/h2/expressions/Row.kt
+++ b/examples/src/main/kotlin/rocks/frieler/kraftsql/h2/expressions/Row.kt
@@ -11,11 +11,4 @@ class Row<T>(values: Map<String, Expression<H2Engine, *>>?) : Row<H2Engine, T>(v
         }
         return "(${values!!.values.joinToString(", ") { value -> value.sql() }})"
     }
-
-    override fun defaultColumnName(): String {
-        if (values == null) {
-            return "NULL"
-        }
-        return values!!.values.joinToString(",") { value -> value.defaultColumnName() }
-    }
 }

--- a/examples/src/main/kotlin/rocks/frieler/kraftsql/h2/expressions/SystemRange.kt
+++ b/examples/src/main/kotlin/rocks/frieler/kraftsql/h2/expressions/SystemRange.kt
@@ -10,7 +10,7 @@ class SystemRange(
     val to: Expression<H2Engine, Long>,
 ) : Data<DataRow> {
 
-    override val columnNames = listOf("X")
+    override val selectableColumnNames = listOf("X")
 
     override fun sql() = "SYSTEM_RANGE(${from.sql()},${to.sql()})"
 }

--- a/examples/src/main/kotlin/rocks/frieler/kraftsql/h2/util/UnnestWorkaround.kt
+++ b/examples/src/main/kotlin/rocks/frieler/kraftsql/h2/util/UnnestWorkaround.kt
@@ -31,7 +31,7 @@ fun Data<*>.unnest(arrayColumn: String, elementColumn: String) : Data<DataRow> {
             Select<DataRow> { from(SystemRange(Constant(1L), Constant(maxElements.toLong()))) }) {
             this["X"] lessOrEqual ArrayLength(Column(arrayColumn))
         }
-        for (column in this@unnest.columnNames) {
+        for (column in this@unnest.selectableColumnNames) {
             column(Column<Any?>(column))
         }
         column(Column<Array<String>>(arrayColumn)[Cast(indizes["X"].knownNotNull(), Types.INTEGER)] `as` elementColumn)

--- a/examples/src/test/kotlin/rocks/frieler/kraftsql/h2/testing/simulator/engine/H2QueryEvaluator.kt
+++ b/examples/src/test/kotlin/rocks/frieler/kraftsql/h2/testing/simulator/engine/H2QueryEvaluator.kt
@@ -1,7 +1,25 @@
 package rocks.frieler.kraftsql.h2.testing.simulator.engine
 
+import rocks.frieler.kraftsql.expressions.And
+import rocks.frieler.kraftsql.expressions.Array
+import rocks.frieler.kraftsql.expressions.ArrayElementReference
+import rocks.frieler.kraftsql.expressions.ArrayLength
+import rocks.frieler.kraftsql.expressions.Cast
+import rocks.frieler.kraftsql.expressions.Coalesce
+import rocks.frieler.kraftsql.expressions.Constant
+import rocks.frieler.kraftsql.expressions.Count
+import rocks.frieler.kraftsql.expressions.Equals
 import rocks.frieler.kraftsql.expressions.Expression
+import rocks.frieler.kraftsql.expressions.IsNotNull
+import rocks.frieler.kraftsql.expressions.LessOrEqual
+import rocks.frieler.kraftsql.expressions.Max
+import rocks.frieler.kraftsql.expressions.Min
+import rocks.frieler.kraftsql.expressions.Not
+import rocks.frieler.kraftsql.expressions.Or
+import rocks.frieler.kraftsql.expressions.Row
+import rocks.frieler.kraftsql.expressions.Sum
 import rocks.frieler.kraftsql.h2.engine.H2Engine
+import rocks.frieler.kraftsql.h2.expressions.ArrayConcatenation
 import rocks.frieler.kraftsql.h2.expressions.Column
 import rocks.frieler.kraftsql.h2.expressions.SystemRange
 import rocks.frieler.kraftsql.h2.objects.Data
@@ -25,7 +43,30 @@ object H2QueryEvaluator : GenericQueryEvaluator<H2Engine>(
         }
 
     override fun fillColumnNames(columns: List<Pair<String?, Expression<H2Engine, *>>>): List<Pair<String, Expression<H2Engine, *>>> =
-        columns.map { (it.first ?: it.second.defaultColumnName()) to it.second }
+        columns.map { (alias, expression) -> (alias ?: expression.defaultColumnName()) to expression }
+
+    private fun Expression<H2Engine, *>.defaultColumnName(): String = when (this) {
+        is And -> "${left.defaultColumnName()}_AND_${right.defaultColumnName()}"
+        is Array<H2Engine, *> -> elements?.joinToString(",", prefix = "[", postfix = "]") { it.defaultColumnName() } ?: "NULL"
+        is ArrayConcatenation<*> -> "${left.defaultColumnName()} || ${right.defaultColumnName()}"
+        is ArrayElementReference -> "${array.defaultColumnName()}[${index.defaultColumnName()}]"
+        is ArrayLength -> "ARRAY_LENGTH(${array.defaultColumnName()})"
+        is Cast -> "CAST(${expression.defaultColumnName()} AS ${type.sql()})"
+        is Coalesce -> "COALESCE(${expressions.joinToString(",") { it.defaultColumnName() }})"
+        is Column<*> -> qualifiedName
+        is Constant -> sql()
+        is Count -> "COUNT(${expression?.defaultColumnName() ?: "*"})"
+        is Equals -> "${left.defaultColumnName()} = ${right.defaultColumnName()}"
+        is IsNotNull -> "${expression.defaultColumnName()}_IS_NOT_NULL"
+        is LessOrEqual -> "${left.defaultColumnName()}<=${right.defaultColumnName()}"
+        is Max<H2Engine, *> -> "MAX(${expression.defaultColumnName()})"
+        is Min<H2Engine, *> -> "MIN(${expression.defaultColumnName()})"
+        is Not -> "NOT_${expression.defaultColumnName()}"
+        is Or -> "${left.defaultColumnName()}_OR_${right.defaultColumnName()}"
+        is Row<H2Engine, *> -> values?.entries?.joinToString(",") { (key, value) -> "$key:${value.defaultColumnName()}" } ?: "NULL"
+        is Sum<H2Engine, *> -> "SUM(${expression.defaultColumnName()})"
+        else -> throw NotImplementedError("Generating a column name for ${this::class.qualifiedName} is not implemented.")
+    }
 
     override fun inferColumns(data: Data<*>) = when (data) {
         is SystemRange -> listOf("X")

--- a/examples/src/test/kotlin/rocks/frieler/kraftsql/h2/testing/simulator/engine/H2QueryEvaluator.kt
+++ b/examples/src/test/kotlin/rocks/frieler/kraftsql/h2/testing/simulator/engine/H2QueryEvaluator.kt
@@ -1,5 +1,6 @@
 package rocks.frieler.kraftsql.h2.testing.simulator.engine
 
+import rocks.frieler.kraftsql.expressions.Expression
 import rocks.frieler.kraftsql.h2.engine.H2Engine
 import rocks.frieler.kraftsql.h2.expressions.Column
 import rocks.frieler.kraftsql.h2.expressions.SystemRange
@@ -22,6 +23,9 @@ object H2QueryEvaluator : GenericQueryEvaluator<H2Engine>(
             is SystemRange -> (expressionEvaluator.simulateExpression(data.from)(DataRow())..expressionEvaluator.simulateExpression(data.to)(DataRow())).map { DataRow("X" to it) }
             else -> super.fetchRows(data, correlatedData)
         }
+
+    override fun fillColumnNames(columns: List<Pair<String?, Expression<H2Engine, *>>>): List<Pair<String, Expression<H2Engine, *>>> =
+        columns.map { (it.first ?: it.second.defaultColumnName()) to it.second }
 
     override fun inferColumns(data: Data<*>) = when (data) {
         is SystemRange -> listOf("X")

--- a/examples/src/test/kotlin/rocks/frieler/kraftsql/h2/testing/simulator/engine/H2QueryEvaluator.kt
+++ b/examples/src/test/kotlin/rocks/frieler/kraftsql/h2/testing/simulator/engine/H2QueryEvaluator.kt
@@ -22,4 +22,9 @@ object H2QueryEvaluator : GenericQueryEvaluator<H2Engine>(
             is SystemRange -> (expressionEvaluator.simulateExpression(data.from)(DataRow())..expressionEvaluator.simulateExpression(data.to)(DataRow())).map { DataRow("X" to it) }
             else -> super.fetchRows(data, correlatedData)
         }
+
+    override fun inferColumns(data: Data<*>) = when (data) {
+        is SystemRange -> listOf("X")
+        else -> super.inferColumns(data)
+    }
 }

--- a/kraftsql-testing/src/main/kotlin/rocks/frieler/kraftsql/testing/simulator/engine/GenericQueryEvaluator.kt
+++ b/kraftsql-testing/src/main/kotlin/rocks/frieler/kraftsql/testing/simulator/engine/GenericQueryEvaluator.kt
@@ -5,7 +5,6 @@ import rocks.frieler.kraftsql.dql.DataExpressionData
 import rocks.frieler.kraftsql.dql.InnerJoin
 import rocks.frieler.kraftsql.dql.Join
 import rocks.frieler.kraftsql.dql.LeftJoin
-import rocks.frieler.kraftsql.dql.Projection
 import rocks.frieler.kraftsql.dql.QuerySource
 import rocks.frieler.kraftsql.dql.QuerySource.Companion.Alias
 import rocks.frieler.kraftsql.dql.RightJoin
@@ -78,24 +77,26 @@ open class GenericQueryEvaluator<E : Engine<E>>(
                 .let { rows -> if (rows.isNotEmpty()) ConstantData(orm, rows) else ConstantData.empty(orm, data.columnNames) }
         }
 
-        val projections = (select.columns ?: select.columnNames.map { Projection(makeColumnReference(it)) })
-            .map { (it.alias ?: it.value.defaultColumnName()) to it.value }
+        val columns = fillColumnNames(
+            select.columns?.map { it.alias to it.value }
+                ?: inferColumns(select).map { null to makeColumnReference(it) }
+        )
 
         val resultRows = if (select.grouping.isNotEmpty()) {
             val groupingExtractors = select.grouping.map { expression -> expressionEvaluator.simulateExpression(expression) }
             val rowGroups = data.items.groupBy { row -> groupingExtractors.map { it.invoke(row) } }.values
 
-            val simulatedProjections = projections
+            val columnSimulations = columns
                 .associate { it.first to expressionEvaluator.simulateAggregation(it.second, select.grouping) }
             rowGroups.map { rowGroup ->
-                DataRow(simulatedProjections.map { (name, expression) -> name to expression.invoke(rowGroup) })
+                DataRow(columnSimulations.map { (name, expression) -> name to expression.invoke(rowGroup) })
             }
-        } else if (projections.all { it.second.isAggregating(true) } && projections.any { it.second.isAggregating(false) }) {
-                val simulatedProjections = projections
+        } else if (columns.all { it.second.isAggregating(true) } && columns.any { it.second.isAggregating(false) }) {
+                val simulatedProjections = columns
                     .associate { it.first to expressionEvaluator.simulateAggregation(it.second, emptyList()) }
                 listOf(DataRow(simulatedProjections.map { (name, expression) -> name to expression.invoke(data.items.toList()) }))
         } else {
-            val simulatedProjections = projections
+            val simulatedProjections = columns
                 .associate { it.first to expressionEvaluator.simulateExpression(it.second) }
             data.items.map { row ->
                 DataRow(simulatedProjections.map { (name, expression) -> name to expression.invoke(row) })
@@ -114,6 +115,20 @@ open class GenericQueryEvaluator<E : Engine<E>>(
      * @return a [Column] reference to the given column name
      */
     protected open fun makeColumnReference(columnName: String) = Column<E, Any?>(columnName)
+
+    /**
+     * Fills the missing column names for the given list of result columns of a query.
+     *
+     * Subclasses can override this method to implement the column name generation strategy of the [Engine] they
+     * simulate.
+     *
+     * @param columns the result columns of the query, maybe lacking a name
+     * @return the resulting columns, all named
+     */
+    protected open fun fillColumnNames(columns: List<Pair<String?, Expression<E, *>>>): List<Pair<String, Expression<E, *>>> =
+        columns.map { (it.first ?: it.second.defaultColumnName()) to it.second }
+
+    protected open fun inferColumns(data: Data<E, *>) = data.columnNames
 
     context(activeState: EngineState<E>)
     protected open fun fetchRows(data: Data<E, *>, correlatedData: DataRow?): List<DataRow> = when (data) {
@@ -135,8 +150,12 @@ open class GenericQueryEvaluator<E : Engine<E>>(
     context(activeState: EngineState<E>)
     private fun resolve(data: Data<E, *>, correlatedData: DataRow? = null) : ConstantData<E, DataRow> {
         val rows = fetchRows(data, correlatedData)
-        return if (rows.isNotEmpty()) ConstantData(orm, rows) else ConstantData.empty(orm, data.columnNames)
+        return if (rows.isNotEmpty()) ConstantData(orm, rows) else ConstantData.empty(orm, inferColumns(data))
     }
+
+    private fun inferColumns(source: QuerySource<E, *>): List<String> =
+        inferColumns(source.data)
+            .map { source.alias?.qualify(it) ?: it }
 
     context(activeState: EngineState<E>)
     private fun resolve(querySource: QuerySource<E, *>, correlatedData: DataRow? = null) : ConstantData<E, DataRow> =
@@ -176,10 +195,11 @@ open class GenericQueryEvaluator<E : Engine<E>>(
             is LeftJoin<E> if (correlatedJoinsEnabled && isCorrelatedJoin(join, leftSide)) -> {
                 val joinCondition = expressionEvaluator.simulateExpression(join.condition)
                 leftSide.items.flatMap { row ->
-                    resolve(join.data, row).items
+                    val dataToJoin = resolve(join.data, row)
+                    dataToJoin.items
                         .map { rowToJoin -> row + rowToJoin }
                         .filter { row -> joinCondition.invoke(row) ?: false }
-                        .ifEmpty { listOf(row + DataRow(join.data.columnNames.map { it to null })) }
+                        .ifEmpty { listOf(row + DataRow(dataToJoin.columnNames.map { it to null })) }
                 }
             }
             is LeftJoin<E> -> {
@@ -189,7 +209,7 @@ open class GenericQueryEvaluator<E : Engine<E>>(
                     dataToJoin.items
                         .map { rowToJoin -> row + rowToJoin }
                         .filter { row -> joinCondition.invoke(row) ?: false }
-                        .ifEmpty { listOf(row + DataRow(join.data.columnNames.map { it to null })) }
+                        .ifEmpty { listOf(row + DataRow(dataToJoin.columnNames.map { it to null })) }
                 }
             }
             is RightJoin<E> -> {
@@ -212,7 +232,7 @@ open class GenericQueryEvaluator<E : Engine<E>>(
             else -> throw NotImplementedError("Simulation of ${join::class.qualifiedName} is not implemented.")
         }
 
-        return if (rows.isNotEmpty()) ConstantData(orm, rows) else ConstantData.empty(orm, leftSide.columnNames + join.data.columnNames)
+        return if (rows.isNotEmpty()) ConstantData(orm, rows) else ConstantData.empty(orm, leftSide.columnNames + inferColumns(join.data))
     }
 
     /**

--- a/kraftsql-testing/src/main/kotlin/rocks/frieler/kraftsql/testing/simulator/engine/GenericQueryEvaluator.kt
+++ b/kraftsql-testing/src/main/kotlin/rocks/frieler/kraftsql/testing/simulator/engine/GenericQueryEvaluator.kt
@@ -128,7 +128,19 @@ open class GenericQueryEvaluator<E : Engine<E>>(
     protected open fun fillColumnNames(columns: List<Pair<String?, Expression<E, *>>>): List<Pair<String, Expression<E, *>>> =
         columns.map { (it.first ?: it.second.defaultColumnName()) to it.second }
 
-    protected open fun inferColumns(data: Data<E, *>) = data.columnNames
+    protected open fun inferColumns(data: Data<E, *>) = when (data) {
+        is ConstantData<*, *> -> data.columnNames
+        is Table<E, *> -> data.columnNames
+        is Select<E, *> -> {
+            if (data.columns != null) {
+                fillColumnNames(data.columns!!.map { it.alias to it.value }).map { it.first }
+            } else {
+                inferColumns(data.source) + data.joins.flatMap { inferColumns(it.data) }
+            }
+        }
+        is DataExpressionData<*, *> -> data.selectableColumnNames
+        else -> throw NotImplementedError("Inferring columns for ${this::class.qualifiedName} is not implemented.")
+    }
 
     context(activeState: EngineState<E>)
     protected open fun fetchRows(data: Data<E, *>, correlatedData: DataRow?): List<DataRow> = when (data) {
@@ -247,12 +259,12 @@ open class GenericQueryEvaluator<E : Engine<E>>(
             is Select<E, *> -> {
                 (data.columns.orEmpty().map { it.value } + listOfNotNull(data.filter) + data.grouping)
                     .flatMap { subexpressionCollector.collectAllSubexpressions(it) }
-                    .any { it is Column<E, *> && it.qualifiedName in left.columnNames }
+                    .any { it is Column<E, *> && it.qualifiedName in left.selectableColumnNames }
             }
             is DataExpressionData<E, *> -> {
                 subexpressionCollector
                     .collectAllSubexpressions(data.expression)
-                    .any { it is Column<E, *> && it.qualifiedName in left.columnNames }
+                    .any { it is Column<E, *> && it.qualifiedName in left.selectableColumnNames }
             }
             else -> false
         }

--- a/kraftsql-testing/src/main/kotlin/rocks/frieler/kraftsql/testing/simulator/engine/GenericQueryEvaluator.kt
+++ b/kraftsql-testing/src/main/kotlin/rocks/frieler/kraftsql/testing/simulator/engine/GenericQueryEvaluator.kt
@@ -21,6 +21,7 @@ import rocks.frieler.kraftsql.objects.Table
 import rocks.frieler.kraftsql.testing.simulator.expressions.GenericExpressionEvaluator
 import rocks.frieler.kraftsql.testing.simulator.expressions.GenericSubexpressionCollector
 import rocks.frieler.kraftsql.testing.simulator.expressions.SubexpressionCollector
+import java.sql.SQLNonTransientException
 import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.ifEmpty
@@ -81,6 +82,12 @@ open class GenericQueryEvaluator<E : Engine<E>>(
             select.columns?.map { it.alias to it.value }
                 ?: inferColumns(select).map { null to makeColumnReference(it) }
         )
+            .also {
+                val duplicateNames = it.groupingBy { (name, _) -> name }.eachCount().filter { (_, count) -> count > 1 }.keys
+                if (duplicateNames.isNotEmpty()) {
+                    throw SQLNonTransientException("Duplicate column names: $duplicateNames")
+                }
+            }
 
         val resultRows = if (select.grouping.isNotEmpty()) {
             val groupingExtractors = select.grouping.map { expression -> expressionEvaluator.simulateExpression(expression) }

--- a/kraftsql-testing/src/main/kotlin/rocks/frieler/kraftsql/testing/simulator/engine/GenericQueryEvaluator.kt
+++ b/kraftsql-testing/src/main/kotlin/rocks/frieler/kraftsql/testing/simulator/engine/GenericQueryEvaluator.kt
@@ -119,6 +119,8 @@ open class GenericQueryEvaluator<E : Engine<E>>(
     /**
      * Fills the missing column names for the given list of result columns of a query.
      *
+     * This generic implementation only fills in the name of a selected [Column]. For all other expressions, it throws a
+     * [NotImplementedError].
      * Subclasses can override this method to implement the column name generation strategy of the [Engine] they
      * simulate.
      *
@@ -126,7 +128,12 @@ open class GenericQueryEvaluator<E : Engine<E>>(
      * @return the resulting columns, all named
      */
     protected open fun fillColumnNames(columns: List<Pair<String?, Expression<E, *>>>): List<Pair<String, Expression<E, *>>> =
-        columns.map { (it.first ?: it.second.defaultColumnName()) to it.second }
+        columns.map {
+            val name = it.first
+                ?: (it.second as? Column<E, *>)?.name
+                ?: throw NotImplementedError("Generating a column name for ${it.second} is not implemented.")
+            name to it.second
+        }
 
     protected open fun inferColumns(data: Data<E, *>) = when (data) {
         is ConstantData<*, *> -> data.columnNames

--- a/kraftsql-testing/src/test/kotlin/rocks/frieler/kraftsql/testing/simulator/engine/GenericEngineSimulatorTest.kt
+++ b/kraftsql-testing/src/test/kotlin/rocks/frieler/kraftsql/testing/simulator/engine/GenericEngineSimulatorTest.kt
@@ -47,11 +47,11 @@ class GenericEngineSimulatorTest {
         val result = context(connection) { simulator.execute(
             Select(
                 source = QuerySource(ConstantData(DummyEngine.orm, DataRow())),
-                columns = listOf(Projection(Constant(42L))),
+                columns = listOf(Projection(Constant(42L), "forty_two")),
             ), DataRow::class
         ) }
 
-        result.single().entries.single().second shouldBe 42L
+        result.single().entries.single() shouldBe Pair("forty_two", 42L)
     }
 
     @Test

--- a/kraftsql-testing/src/test/kotlin/rocks/frieler/kraftsql/testing/simulator/engine/GenericQueryEvaluatorTest.kt
+++ b/kraftsql-testing/src/test/kotlin/rocks/frieler/kraftsql/testing/simulator/engine/GenericQueryEvaluatorTest.kt
@@ -132,7 +132,6 @@ class GenericQueryEvaluatorTest {
     fun `GenericQueryEvaluator can fetch Data by evaluating an expression`() {
         val data = ConstantData(DummyEngine.orm, DataRow("string" to "foo"), DataRow("string" to "bar"), DataRow("string" to "baz"))
         val dataExpression = mock<Expression<DummyEngine, Data<DummyEngine, DataRow>>>(extraInterfaces = arrayOf(HasColumns::class)) {
-            whenever(it.defaultColumnName()).thenReturn("string")
             whenever((it as HasColumns<*, *>).selectableColumnNames).thenReturn(listOf("string"))
         }
         val dataExpressionSimulator = mock<ExpressionSimulator<DummyEngine, Data<DummyEngine, *>, Expression<DummyEngine, Data<DummyEngine, *>>>> {
@@ -156,7 +155,6 @@ class GenericQueryEvaluatorTest {
     fun `GenericQueryEvaluator can fetch Data by evaluating an expression that resolves to Data of primitives`() {
         val data = ConstantData(DummyEngine.orm, "foo", "bar", "baz")
         val dataExpression = mock<Expression<DummyEngine, Data<DummyEngine, DataRow>>>(extraInterfaces = arrayOf(HasColumns::class)) {
-            whenever(it.defaultColumnName()).thenReturn("")
             whenever((it as HasColumns<*, *>).selectableColumnNames).thenReturn(listOf(""))
         }
         val dataExpressionSimulator = mock<ExpressionSimulator<DummyEngine, Data<DummyEngine, *>, Expression<DummyEngine, Data<DummyEngine, *>>>> {
@@ -265,7 +263,7 @@ class GenericQueryEvaluatorTest {
         val leftSide = ConstantData(DummyEngine.orm, DataRow("foo" to "bar"))
         val rightSide = Select<DummyEngine, DataRow>(
             source = QuerySource(ConstantData.empty(DummyEngine.orm, emptyList())),
-            columns = listOf(Projection(Constant(42))),
+            columns = listOf(Projection(Constant(42), "forty_two")),
         )
 
         val result = Select<DummyEngine, DataRow>(
@@ -273,7 +271,7 @@ class GenericQueryEvaluatorTest {
             joins = listOf(LeftJoin(QuerySource(rightSide), Constant(true))),
         ).let { context(state) { queryEvaluator.selectRows(it) } }
 
-        result.single().columnNames shouldContainExactly listOf("foo", "42")
+        result.single().columnNames shouldContainExactly listOf("foo", "forty_two")
     }
 
     @Test
@@ -405,9 +403,7 @@ class GenericQueryEvaluatorTest {
 
     @Test
     fun `GenericQueryEvaluator can simulate correlated CROSS JOIN with Data expression`() {
-        val unnest = mock<Expression<DummyEngine, Data<DummyEngine, Int>>> {
-            whenever(it.defaultColumnName()).thenReturn("")
-        }
+        val unnest = mock<Expression<DummyEngine, Data<DummyEngine, Int>>>()
         val queryEvaluatorPreparedForUnnestInCorrelatedJoin = GenericQueryEvaluator(
             subexpressionCollector = mock<SubexpressionCollector<DummyEngine>> {
                 whenever(it.collectAllSubexpressions(unnest)).thenReturn(listOf(Column<DummyEngine, Int>("values")))
@@ -490,6 +486,16 @@ class GenericQueryEvaluatorTest {
     }
 
     @Test
+    fun `GenericQueryEvaluator cannot generate a column name for an arbitrary expression`() {
+        shouldThrow<NotImplementedError> {
+            Select<DummyEngine, DataRow>(
+                source = QuerySource(ConstantData(DummyEngine.orm, DataRow())),
+                columns = listOf(Projection(mock<Expression<DummyEngine, Int>>())),
+            ).let { context(state) { queryEvaluator.selectRows(it) } }
+        }
+    }
+
+    @Test
     fun `GenericQueryEvaluator selects columns from source and joins when selecting all columns`() {
         val result = Select<DummyEngine, DataRow>(
             source = QuerySource(ConstantData(DummyEngine.orm, DataRow("left" to "foo"))),
@@ -542,7 +548,7 @@ class GenericQueryEvaluatorTest {
     fun `GenericQueryEvaluator can simulate SELECT of a single row by aggregating over all data without grouping`() {
         val result = Select<DummyEngine, DataRow>(
             source = QuerySource(ConstantData(DummyEngine.orm, DataRow("value" to 1), DataRow("value" to 2))),
-            columns = listOf(Projection(Min(Column<DummyEngine, Int>("value"))))
+            columns = listOf(Projection(Min(Column<DummyEngine, Int>("value")), "min_value"))
         ).let { context(state) { queryEvaluator.selectRows(it) } }
 
         result shouldHaveSize 1

--- a/kraftsql-testing/src/test/kotlin/rocks/frieler/kraftsql/testing/simulator/engine/GenericQueryEvaluatorTest.kt
+++ b/kraftsql-testing/src/test/kotlin/rocks/frieler/kraftsql/testing/simulator/engine/GenericQueryEvaluatorTest.kt
@@ -29,6 +29,7 @@ import rocks.frieler.kraftsql.expressions.Min
 import rocks.frieler.kraftsql.objects.ConstantData
 import rocks.frieler.kraftsql.objects.Data
 import rocks.frieler.kraftsql.objects.DataRow
+import rocks.frieler.kraftsql.objects.HasColumns
 import rocks.frieler.kraftsql.objects.Table
 import rocks.frieler.kraftsql.testing.simulator.expressions.ExpressionSimulator
 import rocks.frieler.kraftsql.testing.simulator.expressions.GenericExpressionEvaluator
@@ -130,8 +131,9 @@ class GenericQueryEvaluatorTest {
     @Test
     fun `GenericQueryEvaluator can fetch Data by evaluating an expression`() {
         val data = ConstantData(DummyEngine.orm, DataRow("string" to "foo"), DataRow("string" to "bar"), DataRow("string" to "baz"))
-        val dataExpression = mock<Expression<DummyEngine, Data<DummyEngine, DataRow>>> {
+        val dataExpression = mock<Expression<DummyEngine, Data<DummyEngine, DataRow>>>(extraInterfaces = arrayOf(HasColumns::class)) {
             whenever(it.defaultColumnName()).thenReturn("string")
+            whenever((it as HasColumns<*, *>).selectableColumnNames).thenReturn(listOf("string"))
         }
         val dataExpressionSimulator = mock<ExpressionSimulator<DummyEngine, Data<DummyEngine, *>, Expression<DummyEngine, Data<DummyEngine, *>>>> {
             whenever(it.expression).thenReturn(dataExpression::class)
@@ -153,8 +155,9 @@ class GenericQueryEvaluatorTest {
     @Test
     fun `GenericQueryEvaluator can fetch Data by evaluating an expression that resolves to Data of primitives`() {
         val data = ConstantData(DummyEngine.orm, "foo", "bar", "baz")
-        val dataExpression = mock<Expression<DummyEngine, Data<DummyEngine, DataRow>>> {
+        val dataExpression = mock<Expression<DummyEngine, Data<DummyEngine, DataRow>>>(extraInterfaces = arrayOf(HasColumns::class)) {
             whenever(it.defaultColumnName()).thenReturn("")
+            whenever((it as HasColumns<*, *>).selectableColumnNames).thenReturn(listOf(""))
         }
         val dataExpressionSimulator = mock<ExpressionSimulator<DummyEngine, Data<DummyEngine, *>, Expression<DummyEngine, Data<DummyEngine, *>>>> {
             whenever(it.expression).thenReturn(dataExpression::class)
@@ -255,6 +258,22 @@ class GenericQueryEvaluatorTest {
             DataRow("left.key" to 41, "left.entity" to "x", "right.key" to null, "right.attribute" to null),
             DataRow("left.key" to 42, "left.entity" to "y", "right.key" to 42, "right.attribute" to "foo"),
         )
+    }
+
+    @Test
+    fun `GenericQueryEvaluator can infer joined empty Select's columns`() {
+        val leftSide = ConstantData(DummyEngine.orm, DataRow("foo" to "bar"))
+        val rightSide = Select<DummyEngine, DataRow>(
+            source = QuerySource(ConstantData.empty(DummyEngine.orm, emptyList())),
+            columns = listOf(Projection(Constant(42))),
+        )
+
+        val result = Select<DummyEngine, DataRow>(
+            source = QuerySource(leftSide),
+            joins = listOf(LeftJoin(QuerySource(rightSide), Constant(true))),
+        ).let { context(state) { queryEvaluator.selectRows(it) } }
+
+        result.single().columnNames shouldContainExactly listOf("foo", "42")
     }
 
     @Test

--- a/kraftsql-testing/src/test/kotlin/rocks/frieler/kraftsql/testing/simulator/engine/GenericQueryEvaluatorTest.kt
+++ b/kraftsql-testing/src/test/kotlin/rocks/frieler/kraftsql/testing/simulator/engine/GenericQueryEvaluatorTest.kt
@@ -496,6 +496,16 @@ class GenericQueryEvaluatorTest {
     }
 
     @Test
+    fun `GenericQueryEvaluator rejects duplicate result column names`() {
+        shouldThrow<SQLNonTransientException> {
+            Select<DummyEngine, DataRow>(
+                source = QuerySource(ConstantData(DummyEngine.orm, DataRow())),
+                columns = listOf(Projection(Constant("foo"), "c"), Projection(Constant("bar"), "c")),
+            ).let { context(state) { queryEvaluator.selectRows(it) } }
+        }
+    }
+
+    @Test
     fun `GenericQueryEvaluator selects columns from source and joins when selecting all columns`() {
         val result = Select<DummyEngine, DataRow>(
             source = QuerySource(ConstantData(DummyEngine.orm, DataRow("left" to "foo"))),

--- a/kraftsql-testing/src/test/kotlin/rocks/frieler/kraftsql/testing/simulator/expressions/SubexpressionCollectorTest.kt
+++ b/kraftsql-testing/src/test/kotlin/rocks/frieler/kraftsql/testing/simulator/expressions/SubexpressionCollectorTest.kt
@@ -168,7 +168,6 @@ class SubexpressionCollectorTest {
         val element2 = mock<Expression<DummyEngine, Array<Any?>>>()
         val arrayConcatenation = object : ArrayConcatenation<DummyEngine, Any?>(arrayOf(element1, element2)) {
             override fun sql(): String = TODO("Not yet implemented")
-            override fun defaultColumnName(): String = TODO("Not yet implemented")
         }
 
         val subexpressions = subexpressionCollector.getSubexpressions(arrayConcatenation)

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/dql/DataExpressionData.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/dql/DataExpressionData.kt
@@ -15,12 +15,12 @@ import rocks.frieler.kraftsql.objects.HasColumns
  */
 class DataExpressionData<E : Engine<E>, T : Any>(val expression: Expression<E, Data<E, T>>) : Data<E, T> {
 
-    override val columnNames
+    override val selectableColumnNames: List<String>
         get() =
             if (expression is HasColumns<*, *>) {
-                expression.columnNames
+                expression.selectableColumnNames
             } else {
-                listOf(expression.defaultColumnName())
+                emptyList()
             }
 
     override fun sql() = expression.sql()

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/dql/QuerySource.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/dql/QuerySource.kt
@@ -30,11 +30,11 @@ open class QuerySource<E: Engine<E>, T : Any>(
         .let { sql -> if (alias != null) "$sql AS `${alias.value}`" else sql }
 
     /**
-     * The names of the available [rocks.frieler.kraftsql.objects.Column]s, which are the columns of the underlying
-     * [Data], prefixed with this [QuerySource]'s alias if set.
+     * The names of the selectable [rocks.frieler.kraftsql.objects.Column]s, which are the selectable columns of the
+     * underlying [Data], prefixed with this [QuerySource]'s alias if set.
      */
-    override val columnNames: List<String>
-        get() = data.columnNames.map { alias?.qualify(it) ?: it }
+    override val selectableColumnNames: List<String>
+        get() = data.selectableColumnNames.map { alias?.qualify(it) ?: it }
 
     /**
      * Retrieves a [Column] expression for the named column.
@@ -50,9 +50,9 @@ open class QuerySource<E: Engine<E>, T : Any>(
      * @return a [Column] expression for the named column
      */
     override operator fun get(column: String) : Column<E, Any?> =
-        if (column == alias?.value && data.columnNames == listOf("")) {
+        if (column == alias?.value && data.selectableColumnNames == listOf("")) {
             Column(alias.value)
-        } else if (alias != null && column.startsWith("${alias.value}.") && column.removePrefix("${alias.value}.") in data.columnNames) {
+        } else if (alias != null && column.startsWith("${alias.value}.") && column.removePrefix("${alias.value}.") in data.selectableColumnNames) {
             get(column.removePrefix("${alias.value}."))
         } else {
             data[column].let { if (alias != null) it.withQualifier(alias.value) else it }

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/dql/Select.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/dql/Select.kt
@@ -3,6 +3,7 @@ package rocks.frieler.kraftsql.dql
 import rocks.frieler.kraftsql.commands.Command
 import rocks.frieler.kraftsql.engine.Connection
 import rocks.frieler.kraftsql.engine.Engine
+import rocks.frieler.kraftsql.expressions.Column
 import rocks.frieler.kraftsql.expressions.Expression
 import rocks.frieler.kraftsql.objects.Data
 import java.util.Objects
@@ -22,15 +23,15 @@ open class Select<E : Engine<E>, T : Any>(
 ) : Command<E, List<T>>, Data<E, T> {
 
     /**
-     * The names of the columns this [Select] returns.
+     * The names of the known, i.e., named columns this [Select] returns.
      */
     @Suppress("IfThenToElvis")
-    override val columnNames: List<String>
+    override val selectableColumnNames: List<String>
         get() =
             if (columns != null) {
-                columns.map { it.alias ?: it.value.defaultColumnName() }
+                columns.mapNotNull { it.alias ?: (it.value as? Column)?.qualifiedName }
             } else {
-                source.columnNames + joins.flatMap { it.data.columnNames }
+                source.selectableColumnNames + joins.flatMap { it.data.selectableColumnNames }
             }
 
     override fun sql() = """

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/And.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/And.kt
@@ -16,8 +16,6 @@ class And<E : Engine<E>>(
 ) : Expression<E, Boolean?> {
     override fun sql() = "(${left.sql()}) AND (${right.sql()})"
 
-    override fun defaultColumnName() = "${left.defaultColumnName()}_AND_${right.defaultColumnName()}"
-
     override fun equals(other: Any?) = other is And<*>
             && left == other.left
             && right == other.right

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Array.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Array.kt
@@ -19,13 +19,6 @@ class Array<E : Engine<E>, T>(
         return "ARRAY [${elements.joinToString(",") { it.sql() }}]"
     }
 
-    override fun defaultColumnName(): String {
-        if (elements == null) {
-            return "NULL"
-        }
-        return "[${elements.joinToString(",") { it.defaultColumnName() }}]"
-    }
-
     override fun equals(other: Any?) = other is Array<E, *> && elements.contentEquals(other.elements)
 
     override fun hashCode() = elements.hashCode()

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/ArrayElementReference.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/ArrayElementReference.kt
@@ -20,8 +20,6 @@ class ArrayElementReference<E : Engine<E>, T>(
 ) : Expression<E, T?> {
     override fun sql() = "${array.sql()}[${index.sql()}]"
 
-    override fun defaultColumnName() = "${array.defaultColumnName()}[${index.defaultColumnName()}]"
-
     override fun equals(other: Any?) = other is ArrayElementReference<E, T>
             && array == other.array
             && index == other.index

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/ArrayLength.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/ArrayLength.kt
@@ -14,8 +14,6 @@ class ArrayLength<E : Engine<E>>(
 ) : Expression<E, Int?> {
     override fun sql() = "ARRAY_LENGTH(${array.sql()})"
 
-    override fun defaultColumnName() = "ARRAY_LENGTH(${array.defaultColumnName()})"
-
     override fun equals(other: Any?) = other is ArrayLength<E>
             && array == other.array
 

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Cast.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Cast.kt
@@ -22,8 +22,6 @@ class Cast<E : Engine<E>, T> : Expression<E, T> {
 
     override fun sql() = "CAST(${expression.sql()} AS ${type.sql()})"
 
-    override fun defaultColumnName() = "CAST(${expression.defaultColumnName()} AS ${type.sql()})"
-
     override fun equals(other: Any?) = other is Cast<*, *> && expression == other.expression && type == other.type
 
     override fun hashCode() = expression.hashCode() + type.hashCode()

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Coalesce.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Coalesce.kt
@@ -29,8 +29,6 @@ class Coalesce<E : Engine<E>, T>(
 
     override fun sql() = "COALESCE(${this@Coalesce.expressions.joinToString(",") { it.sql() }})"
 
-    override fun defaultColumnName() = "COALESCE(${this@Coalesce.expressions.joinToString(",") { it.defaultColumnName() }})"
-
     override fun equals(other: Any?) = other is Coalesce<E, T>
             && this@Coalesce.expressions == other.expressions
 

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Column.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Column.kt
@@ -31,11 +31,11 @@ open class Column<E: Engine<E>, T>(
      * In case this [Column] has a structured type with sub-columns, this should provide the names of those.
      * Unfortunately, the [Column] expression holds no information about the referenced column and its type. This
      * information is contextual, as it depends on the data this expression is evaluated against. Explore that data's
-     * schema, if you need this kind of information.
+     * schema if you need this kind of information.
      *
      * @throws NotImplementedError ALWAYS!
      */
-    override val columnNames: List<String>
+    override val selectableColumnNames: List<String>
         get() = throw NotImplementedError("Column names of possibly structured columns are not yet supported.")
 
     /**

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Column.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Column.kt
@@ -23,8 +23,6 @@ open class Column<E: Engine<E>, T>(
 
     override fun sql(): String = "${qualifiers.joinToString("") { "`$it`." }}`$name`"
 
-    override fun defaultColumnName() = qualifiedName
-
     /**
      * WARNING: Not implemented!
      *

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Constant.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Constant.kt
@@ -25,8 +25,6 @@ open class Constant<E : Engine<E>, T>(
         }
     }
 
-    override fun defaultColumnName() = sql()
-
     override fun equals(other: Any?) = other is Constant<E, T> && value == other.value
 
     override fun hashCode() = value.hashCode()

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Count.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Count.kt
@@ -14,8 +14,6 @@ class Count<E : Engine<E>>(
 ) : Aggregation<E, Long> {
     override fun sql() = "COUNT(${expression?.sql() ?: "*"})"
 
-    override fun defaultColumnName() = "COUNT(${expression?.defaultColumnName() ?: "*"})"
-
     override fun equals(other: Any?) = other is Count<*>
         && expression == other.expression
 

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Equals.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Equals.kt
@@ -16,8 +16,6 @@ class Equals<E : Engine<E>>(
 ) : Expression<E, Boolean> {
     override fun sql() = "(${left.sql()})=(${right.sql()})"
 
-    override fun defaultColumnName() = "${left.defaultColumnName()} = ${right.defaultColumnName()}"
-
     override fun equals(other: Any?) = other is Equals<E> && left == other.left && right == other.right
 
     override fun hashCode() = Objects.hash(left, right)

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Expression.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Expression.kt
@@ -16,13 +16,6 @@ interface Expression<E: Engine<E>, out T> {
      */
     fun sql(): String
 
-    /**
-     * Returns the name of the resulting column, when this [Expression] is `SELECT`ed without an alias.
-     *
-     * @return the default column name  when `SELECT`ing this [Expression] without an alias
-     */
-    fun defaultColumnName(): String
-
     override fun equals(other: Any?) : Boolean
 
     override fun hashCode(): Int

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/IsNotNull.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/IsNotNull.kt
@@ -14,8 +14,6 @@ class IsNotNull<E : Engine<E>>(
 ) : Expression<E, Boolean> {
     override fun sql() = "${expression.sql()} IS NOT NULL"
 
-    override fun defaultColumnName() = "${expression.defaultColumnName()}_IS_NOT_NULL"
-
     override fun equals(other: Any?) = other is IsNotNull<*> && expression == other.expression
 
     override fun hashCode() = Objects.hash(expression)

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/LessOrEqual.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/LessOrEqual.kt
@@ -16,8 +16,6 @@ class LessOrEqual<E : Engine<E>>(
 ) : Expression<E, Boolean?> {
     override fun sql() = "(${left.sql()})<=(${right.sql()})"
 
-    override fun defaultColumnName() = "${left.defaultColumnName()}<=${right.defaultColumnName()}"
-
     override fun equals(other: Any?) = other is LessOrEqual<E>
             && left == other.left
             && right == other.right

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Max.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Max.kt
@@ -13,8 +13,6 @@ class Max<E : Engine<E>, T : Comparable<T>?>(
 ) : Aggregation<E, T?> {
     override fun sql() = "MAX(${expression.sql()})"
 
-    override fun defaultColumnName() = "MAX(${expression.defaultColumnName()})"
-
     override fun equals(other: Any?) = other is Max<E, T>
             && expression == other.expression
 

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Min.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Min.kt
@@ -13,8 +13,6 @@ class Min<E : Engine<E>, T : Comparable<T>?>(
 ) : Aggregation<E, T?> {
     override fun sql() = "MIN(${expression.sql()})"
 
-    override fun defaultColumnName() = "MIN(${expression.defaultColumnName()})"
-
     override fun equals(other: Any?) = other is Min<E, T>
             && expression == other.expression
 

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Not.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Not.kt
@@ -14,8 +14,6 @@ class Not<E : Engine<E>>(
 ) : Expression<E, Boolean?> {
     override fun sql() = "NOT (${expression.sql()})"
 
-    override fun defaultColumnName() = "NOT_${expression.defaultColumnName()}"
-
     override fun equals(other: Any?) = other is Not<*>
             && expression == other.expression
 

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Or.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Or.kt
@@ -16,8 +16,6 @@ class Or<E : Engine<E>>(
 ) : Expression<E, Boolean?> {
     override fun sql() = "(${left.sql()}) OR (${right.sql()})"
 
-    override fun defaultColumnName() = "${left.defaultColumnName()}_OR_${right.defaultColumnName()}"
-
     override fun equals(other: Any?) = other is Or<*>
             && left == other.left
             && right == other.right

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Row.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Row.kt
@@ -19,13 +19,6 @@ open class Row<E : Engine<E>, T>(
         return "(${values.entries.joinToString(", ") { (key, value) -> "${value.sql()} AS `$key`" }})"
     }
 
-    override fun defaultColumnName(): String {
-        if (values == null) {
-            return "NULL"
-        }
-        return values.entries.joinToString(",") { (key, value) -> "$key:${value.defaultColumnName()}" }
-    }
-
     override fun equals(other: Any?) = other is Row<E, *> && values == other.values
 
     override fun hashCode() = values.hashCode()

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Sum.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/expressions/Sum.kt
@@ -20,8 +20,6 @@ abstract class Sum<E : Engine<E>, T : Number> protected constructor(
 
     override fun sql() = "SUM(${expression.sql()})"
 
-    override fun defaultColumnName() = "SUM(${expression.defaultColumnName()})"
-
     override fun equals(other: Any?) = other is Sum<E, T> && expression == other.expression
 
     override fun hashCode() = expression.hashCode()

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/objects/ConstantData.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/objects/ConstantData.kt
@@ -17,7 +17,7 @@ open class ConstantData<E : Engine<E>, T : Any> protected constructor(
      * The items - or rows - in this data.
      */
     val items: Iterable<T>,
-    override val columnNames: List<String>,
+    val columnNames: List<String>,
 ) : Data<E, T> {
 
     /**
@@ -75,6 +75,12 @@ open class ConstantData<E : Engine<E>, T : Any> protected constructor(
         inline fun <E : Engine<E>, reified T : Any> empty(orm: ORMapping<E, *>) =
             empty<E, T>(orm, orm.getSchemaFor(T::class).map { it.name })
     }
+
+    /**
+     * All [columnNames] of this [ConstantData].
+     */
+    override val selectableColumnNames: List<String>
+        get() = columnNames
 
     override fun sql(): String {
         return if (items.none()) {

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/objects/HasColumns.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/objects/HasColumns.kt
@@ -14,14 +14,16 @@ import kotlin.reflect.KProperty1
 interface HasColumns<E : Engine<E>, T> {
 
     /**
-     * The names of the available [rocks.frieler.kraftsql.objects.Column]s.
+     * The names of the selectable [rocks.frieler.kraftsql.objects.Column]s.
+     *
+     * There can be more columns at runtime without a name that would allow them to be referenced in SQL.
      */
-    val columnNames: List<String>
+    val selectableColumnNames: List<String>
 
     /**
      * Retrieves a [Column] expression for the named column.
      *
-     * The name must be in the available [columnNames].
+     * The name must be in the [selectableColumnNames].
      *
      * If the data object adds any qualifier, such as an alias, to the columns, this qualifier is added to the [Column]
      * expression, but optional in the given column name.
@@ -30,7 +32,7 @@ interface HasColumns<E : Engine<E>, T> {
      * @return a [Column] expression for the named column
      */
     operator fun get(column: String) : Column<E, Any?> {
-        require(column in columnNames) { "No column '$column'; did you mean one of $columnNames?" }
+        require(column in selectableColumnNames) { "No column '$column'; did you mean one of $selectableColumnNames?" }
         return Column(column)
     }
 

--- a/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/objects/Table.kt
+++ b/kraftsql/src/main/kotlin/rocks/frieler/kraftsql/objects/Table.kt
@@ -26,8 +26,14 @@ open class Table<E: Engine<E>, T : Any>(
     /**
      * The names of this [Table]'s [Column]s.
      */
-    override val columnNames: List<String>
+    val columnNames: List<String>
         get() = columns.map { it.name }
+
+    /**
+     * All [columnNames] of this [Table].
+     */
+    override val selectableColumnNames: List<String>
+        get() = columnNames
 
     /**
      * Retrieves a [rocks.frieler.kraftsql.expressions.Column] expression for the named column.

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/dql/DataExpressionDataTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/dql/DataExpressionDataTest.kt
@@ -1,5 +1,6 @@
 package rocks.frieler.kraftsql.dql
 
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
@@ -16,19 +17,17 @@ class DataExpressionDataTest {
     private val dataExpressionData = DataExpressionData(expression)
 
     @Test
-    fun `columnNames returns the expressions default column name`() {
-        whenever(expression.defaultColumnName()).thenReturn("DATA()")
-
-        dataExpressionData.columnNames shouldBe listOf(expression.defaultColumnName())
+    fun `selectableColumnNames returns empty list when expression has no columns`() {
+        dataExpressionData.selectableColumnNames.shouldBeEmpty()
     }
 
     @Test
-    fun `columnNames returns columns from expression if it has columns`() {
+    fun `selectableColumnNames returns selectable columns from expression if it has columns`() {
         val expressionWithColumns = mock<Expression<TestableDummyEngine, Data<TestableDummyEngine, DataRow>>>(
             extraInterfaces = arrayOf(HasColumns::class)
-        ) { whenever((it as HasColumns<*, *>).columnNames).thenReturn(listOf("c1", "c2")) }
+        ) { whenever((it as HasColumns<*, *>).selectableColumnNames).thenReturn(listOf("c1", "c2")) }
 
-        DataExpressionData(expressionWithColumns).columnNames shouldBe listOf("c1", "c2")
+        DataExpressionData(expressionWithColumns).selectableColumnNames shouldBe listOf("c1", "c2")
     }
 
     @Test
@@ -40,8 +39,6 @@ class DataExpressionDataTest {
 
     @Test
     fun `DataExpressionData provides maybe non-existent Column by name`() { // because column names are not reliable atm
-        whenever(expression.defaultColumnName()).thenReturn("")
-
         dataExpressionData["something"] shouldBe Column("something")
     }
 }

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/dql/QuerySourceTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/dql/QuerySourceTest.kt
@@ -47,30 +47,30 @@ class QuerySourceTest {
 
 
     @Test
-    fun `column names are forwarded from underlying data`() {
-        whenever(data.columnNames).thenReturn(listOf("c1", "c2"))
+    fun `selectable column names are forwarded from underlying data`() {
+        whenever(data.selectableColumnNames).thenReturn(listOf("c1", "c2"))
 
-        QuerySource(data).columnNames shouldBe data.columnNames
+        QuerySource(data).selectableColumnNames shouldBe data.selectableColumnNames
     }
 
     @Test
-    fun `column names are prefixed with the alias`() {
-        whenever(data.columnNames).thenReturn(listOf("c1"))
+    fun `selectable column names are prefixed with the alias`() {
+        whenever(data.selectableColumnNames).thenReturn(listOf("c1"))
 
-        QuerySource(data, Alias("a")).columnNames shouldBe listOf("a.c1")
+        QuerySource(data, Alias("a")).selectableColumnNames shouldBe listOf("a.c1")
     }
 
     @Test
     fun `empty column name is replaced by alias`() {
-        whenever(data.columnNames).thenReturn(listOf(""))
+        whenever(data.selectableColumnNames).thenReturn(listOf(""))
 
-        QuerySource(data, Alias("a")).columnNames shouldBe listOf("a")
+        QuerySource(data, Alias("a")).selectableColumnNames shouldBe listOf("a")
     }
 
     @Test
     fun `get operator provides column expression by name from underlying data`() {
         val column = mock<Column<TestableDummyEngine, Any?>> { whenever(it.name).thenReturn("c1") }
-        whenever(data.columnNames).thenReturn(listOf("c1"))
+        whenever(data.selectableColumnNames).thenReturn(listOf("c1"))
         whenever(data["c1"]).thenReturn(column)
 
         QuerySource(data)["c1"] shouldBe column
@@ -81,7 +81,7 @@ class QuerySourceTest {
         val column = mock<Column<TestableDummyEngine, Any?>> {
             whenever(it.name).thenReturn("c1")
         }
-        whenever(data.columnNames).thenReturn(listOf("c1"))
+        whenever(data.selectableColumnNames).thenReturn(listOf("c1"))
         whenever(data["c1"]).thenReturn(column)
         whenever(column.withQualifier("a")).thenReturn(Column(listOf("a"), "c1"))
 
@@ -96,7 +96,7 @@ class QuerySourceTest {
         val column = mock<Column<TestableDummyEngine, Any?>> {
             whenever(it.name).thenReturn("c1")
         }
-        whenever(data.columnNames).thenReturn(listOf("c1"))
+        whenever(data.selectableColumnNames).thenReturn(listOf("c1"))
         whenever(data["c1"]).thenReturn(column)
         whenever(column.withQualifier("a")).thenReturn(Column(listOf("a"), "c1"))
 
@@ -108,10 +108,24 @@ class QuerySourceTest {
 
     @Test
     fun `get operator provides only column like alias when underlying data has only one column with empty name`() {
-        whenever(data.columnNames).thenReturn(listOf(""))
+        whenever(data.selectableColumnNames).thenReturn(listOf(""))
 
         val column = QuerySource(data, Alias("a"))["a"]
 
         column shouldBe Column("a")
+    }
+}
+
+class QuerySourceAliasTest {
+    private val alias = Alias("a")
+
+    @Test
+    fun `qualify() prefixes column name with alias`() {
+        alias.qualify("c") shouldBe "a.c"
+    }
+
+    @Test
+    fun `qualify() names unnamed column by alias`() {
+        alias.qualify("") shouldBe "a"
     }
 }

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/dql/SelectTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/dql/SelectTest.kt
@@ -5,42 +5,53 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import rocks.frieler.kraftsql.engine.TestableDummyEngine
-import rocks.frieler.kraftsql.expressions.Expression
+import rocks.frieler.kraftsql.expressions.Column
 import rocks.frieler.kraftsql.objects.DataRow
 
 class SelectTest {
     private val source = mock<QuerySource<TestableDummyEngine, DataRow>>()
 
     @Test
-    fun `columnNames provides the explicitly selected columns`() {
+    fun `selectableColumnNames provides the explicitly selected and named expressions`() {
         val projectionWithAlias = mock<Projection<TestableDummyEngine, *>> { whenever(it.alias).thenReturn("a") }
         val projectionWithoutAlias = mock<Projection<TestableDummyEngine, *>> {
             whenever(it.alias).thenReturn(null)
-            val value = mock<Expression<TestableDummyEngine, *>> { e -> whenever(e.defaultColumnName()).thenReturn("x") }
-            whenever(it.value).thenReturn(value)
         }
 
         val select = Select<TestableDummyEngine, DataRow>(source, columns = listOf(projectionWithAlias, projectionWithoutAlias))
 
-        select.columnNames shouldBe listOf(projectionWithAlias.alias, projectionWithoutAlias.value.defaultColumnName())
+        select.selectableColumnNames shouldBe listOf(projectionWithAlias.alias)
     }
 
     @Test
-    fun `columnNames provides columns from underlying source selected by wildcard`() {
-        whenever(source.columnNames).thenReturn(listOf("c1", "c2"))
+    fun `selectableColumnNames provides the name from selected Column without alias`() {
+        val selectedColumn = mock<Column<TestableDummyEngine, *>> { whenever(it.qualifiedName).thenReturn("data.col") }
+        val projectionOfColumnWithoutAlias = mock<Projection<TestableDummyEngine, *>> {
+            whenever(it.alias).thenReturn(null)
+            whenever(it.value).thenReturn(selectedColumn)
+        }
+
+        val select = Select<TestableDummyEngine, DataRow>(source, columns = listOf(projectionOfColumnWithoutAlias))
+
+        select.selectableColumnNames shouldBe listOf(selectedColumn.qualifiedName)
+    }
+
+    @Test
+    fun `selectableColumnNames provides selectable columns from underlying source selected by wildcard`() {
+        whenever(source.selectableColumnNames).thenReturn(listOf("c1", "c2"))
 
         val select = Select<TestableDummyEngine, DataRow>(source)
 
-        select.columnNames shouldBe source.columnNames
+        select.selectableColumnNames shouldBe source.selectableColumnNames
     }
 
     @Test
-    fun `columnNames provides columns from underlying source and joined sources selected by wildcard`() {
-        whenever(source.columnNames).thenReturn(listOf("c1", "c2"))
-        val joinedData = mock<QuerySource<TestableDummyEngine, DataRow>> { whenever(it.columnNames).thenReturn(listOf("c3")) }
+    fun `selectableColumnNames provides selectable columns from underlying source and joined sources selected by wildcard`() {
+        whenever(source.selectableColumnNames).thenReturn(listOf("c1", "c2"))
+        val joinedData = mock<QuerySource<TestableDummyEngine, DataRow>> { whenever(it.selectableColumnNames).thenReturn(listOf("c3")) }
 
         val select = Select<TestableDummyEngine, DataRow>(source, joins = listOf(InnerJoin(joinedData, mock())))
 
-        select.columnNames shouldBe source.columnNames + joinedData.columnNames
+        select.selectableColumnNames shouldBe source.selectableColumnNames + joinedData.selectableColumnNames
     }
 }

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/AndTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/AndTest.kt
@@ -20,16 +20,6 @@ class AndTest {
     }
 
     @Test
-    fun `default column name is constructed from left and right`() {
-        val left = mock<Expression<TestableDummyEngine, Boolean>> { whenever(it.defaultColumnName()).thenReturn("left") }
-        val right = mock<Expression<TestableDummyEngine, Boolean>> { whenever(it.defaultColumnName()).thenReturn("right") }
-
-        val and = And(left, right)
-
-        and.defaultColumnName() shouldBe "left_AND_right"
-    }
-
-    @Test
     fun `And with equal arguments is equal`() {
         val left = mock<Expression<TestableDummyEngine, Boolean?>>()
         val right = mock<Expression<TestableDummyEngine, Boolean?>>()

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/ArrayConcatenationTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/ArrayConcatenationTest.kt
@@ -11,7 +11,6 @@ import kotlin.Array
 class ArrayConcatenationTest {
     private class TestableArrayConcatenation<T>(arguments: Array<Expression<TestableDummyEngine, Array<T>?>>) : ArrayConcatenation<TestableDummyEngine, T>(arguments) {
         override fun sql(): String = TODO("Not yet implemented")
-        override fun defaultColumnName(): String = TODO("Not yet implemented")
     }
 
     @Test

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/ArrayElementReferenceTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/ArrayElementReferenceTest.kt
@@ -25,20 +25,6 @@ class ArrayElementReferenceTest {
     }
 
     @Test
-    fun `defaultColumnName() puts default column names into SQL syntax`() {
-        val arrayExpression = mock<Expression<TestableDummyEngine, Array<Any>>> {
-            whenever(it.defaultColumnName()).thenReturn("array")
-        }
-        val indexExpression = mock<Expression<TestableDummyEngine, Int>> {
-            whenever(it.defaultColumnName()).thenReturn("index")
-        }
-
-        val elementReference = ArrayElementReference(arrayExpression, indexExpression)
-
-        elementReference.defaultColumnName() shouldBe "array[index]"
-    }
-
-    @Test
     fun `ArrayElementReferences with equal arguments are equal`() {
         val arrayExpression = mock<Expression<TestableDummyEngine, Array<Any?>>>()
         val indexExpression = mock<Expression<TestableDummyEngine, Int>>()

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/ArrayLengthTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/ArrayLengthTest.kt
@@ -20,17 +20,6 @@ class ArrayLengthTest {
     }
 
     @Test
-    fun `defaultColumnName() wraps array expression's default column name in function call`() {
-        val arrayExpression = mock<Expression<TestableDummyEngine, kotlin.Array<*>>>{
-            whenever(it.defaultColumnName()).thenReturn("array")
-        }
-
-        val arrayLength = ArrayLength(arrayExpression)
-
-        arrayLength.defaultColumnName() shouldBe "ARRAY_LENGTH(array)"
-    }
-
-    @Test
     fun `ArrayLengths with equal argument are equal`() {
         val arrayExpression = mock<Expression<TestableDummyEngine, kotlin.Array<*>>>()
 

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/CoalesceTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/CoalesceTest.kt
@@ -21,16 +21,6 @@ class CoalesceTest {
     }
 
     @Test
-    fun `default column name renders COALESCE() with argument's default column names`() {
-        val expression1 = mock<Expression<TestableDummyEngine, Any?>> { whenever(it.defaultColumnName()).thenReturn("x") }
-        val expression2 = mock<Expression<TestableDummyEngine, Any?>> { whenever(it.defaultColumnName()).thenReturn("y") }
-
-        val sql = Coalesce(expression1, expression2).defaultColumnName()
-
-        sql shouldMatch "COALESCE\\(${expression1.defaultColumnName()},\\s*${expression2.defaultColumnName()}\\)"
-    }
-
-    @Test
     fun `Coalesce is non nullable when last expression is non nullable`() {
         val nullableExpressions = mock<Expression<TestableDummyEngine, Any?>>()
         val nonNullableExpression = mock<Expression<TestableDummyEngine, Any>>()

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/ColumnTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/ColumnTest.kt
@@ -12,7 +12,7 @@ class ColumnTest {
     @Test
     fun `Column cannot provide possible sub-column names`() {
         shouldThrow<NotImplementedError> {
-            column.columnNames
+            column.selectableColumnNames
         }
     }
 

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/CountTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/CountTest.kt
@@ -28,22 +28,6 @@ class CountTest {
     }
 
     @Test
-    fun `default column name renders COUNT() with asterisk when counting all rows`() {
-        val sql = Count().defaultColumnName()
-
-        sql shouldBe "COUNT(*)"
-    }
-
-    @Test
-    fun `default column name renders COUNT() with argument's default column name`() {
-        val expression = mock<Expression<TestableDummyEngine, Any?>> { whenever(it.defaultColumnName()).thenReturn("x") }
-
-        val sql = Count(expression).defaultColumnName()
-
-        sql shouldBe "COUNT(${expression.defaultColumnName()})"
-    }
-
-    @Test
     fun `Count with equal argument is equal`() {
         val expression = mock<Expression<TestableDummyEngine, Any?>>()
 

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/IsNotNullTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/IsNotNullTest.kt
@@ -16,12 +16,4 @@ class IsNotNullTest {
         IsNotNull(expression).sql() shouldBe "e IS NOT NULL"
     }
 
-    @Test
-    fun `IsNotNull's default column name is expression's default column name with '_IS_NOT_NULL' suffix`() {
-        val expression = mock<Expression<TestableDummyEngine, *>> {
-            whenever(it.defaultColumnName()).thenReturn("e")
-        }
-
-        IsNotNull(expression).defaultColumnName() shouldBe "e_IS_NOT_NULL"
-    }
 }

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/LessOrEqualTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/LessOrEqualTest.kt
@@ -20,16 +20,6 @@ class LessOrEqualTest {
     }
 
     @Test
-    fun `default column name is constructed from left and right`() {
-        val left = mock<Expression<TestableDummyEngine, *>> { whenever(it.defaultColumnName()).thenReturn("left") }
-        val right = mock<Expression<TestableDummyEngine, *>> { whenever(it.defaultColumnName()).thenReturn("right") }
-
-        val lessOrEqual = LessOrEqual(left, right)
-
-        lessOrEqual.defaultColumnName() shouldBe "left<=right"
-    }
-
-    @Test
     fun `LessOrEqual with equal arguments is equal`() {
         val left = mock<Expression<TestableDummyEngine, *>>()
         val right = mock<Expression<TestableDummyEngine, *>>()

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/MaxTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/MaxTest.kt
@@ -21,17 +21,6 @@ class MaxTest {
     }
 
     @Test
-    fun `default column name renders MAX() with argument's default column name`() {
-        val expression = mock<Expression<TestableDummyEngine, Int?>> {
-            whenever(it.defaultColumnName()).thenReturn("x")
-        }
-
-        val sql = Max(expression).defaultColumnName()
-
-        sql shouldBe "MAX(${expression.defaultColumnName()})"
-    }
-
-    @Test
     fun `Max with equal argument is equal`() {
         val expression = mock<Expression<TestableDummyEngine, Int?>>()
 

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/MinTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/MinTest.kt
@@ -21,17 +21,6 @@ class MinTest {
     }
 
     @Test
-    fun `default column name renders MIN() with argument's default column name`() {
-        val expression = mockk<Expression<TestableDummyEngine, Int?>> {
-            every { defaultColumnName() } returns "x"
-        }
-
-        val sql = Min(expression).defaultColumnName()
-
-        sql shouldBe "MIN(${expression.defaultColumnName()})"
-    }
-
-    @Test
     fun `Min with equal argument is equal`() {
         val expression = mockk<Expression<TestableDummyEngine, Int?>>()
 

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/NotTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/NotTest.kt
@@ -19,15 +19,6 @@ class NotTest {
     }
 
     @Test
-    fun `default column name is constructed from expression`() {
-        val expression = mock<Expression<TestableDummyEngine, Boolean>> { whenever(it.defaultColumnName()).thenReturn("expr") }
-
-        val not = Not(expression)
-
-        not.defaultColumnName() shouldBe "NOT_expr"
-    }
-
-    @Test
     fun `Not with equal argument is equal`() {
         val expression = mock<Expression<TestableDummyEngine, Boolean?>>()
 

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/OrTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/expressions/OrTest.kt
@@ -20,16 +20,6 @@ class OrTest {
     }
 
     @Test
-    fun `default column name is constructed from left and right`() {
-        val left = mock<Expression<TestableDummyEngine, Boolean>> { whenever(it.defaultColumnName()).thenReturn("left") }
-        val right = mock<Expression<TestableDummyEngine, Boolean>> { whenever(it.defaultColumnName()).thenReturn("right") }
-
-        val or = Or(left, right)
-
-        or.defaultColumnName() shouldBe "left_OR_right"
-    }
-
-    @Test
     fun `Or with equal arguments is equal`() {
         val left = mock<Expression<TestableDummyEngine, Boolean?>>()
         val right = mock<Expression<TestableDummyEngine, Boolean?>>()

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/objects/ConstantDataTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/objects/ConstantDataTest.kt
@@ -105,6 +105,13 @@ class ConstantDataTest {
     }
 
     @Test
+    fun `selectableColumnNames offers all columns`() {
+        val data = ConstantData.empty<TestableDummyEngine, DataRow>(orm, listOf("c1", "c2"))
+
+        data.selectableColumnNames shouldBe data.columnNames
+    }
+
+    @Test
     fun `SQL selects empty data of item schema`() {
         val emptyData = ConstantData.empty<TestableDummyEngine, DataRow>(orm, listOf("c1", "c2"))
 

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/objects/HasColumnsTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/objects/HasColumnsTest.kt
@@ -20,8 +20,8 @@ class HasColumnsTest {
     }
 
     @Test
-    fun `get operator returns Column expression for name of existing column`() {
-        whenever(testableHasColumnsInstance.columnNames).thenReturn(listOf("col"))
+    fun `get operator returns Column expression for name of selectable column`() {
+        whenever(testableHasColumnsInstance.selectableColumnNames).thenReturn(listOf("col"))
 
         val column = testableHasColumnsInstance["col"]
 
@@ -30,8 +30,8 @@ class HasColumnsTest {
     }
 
     @Test
-    fun `get operator rejects to provide Column expression for name of non-existent column`() {
-        whenever(testableHasColumnsInstance.columnNames).thenReturn(listOf("foo"))
+    fun `get operator rejects to provide Column expression for name of non-selectable column`() {
+        whenever(testableHasColumnsInstance.selectableColumnNames).thenReturn(listOf("foo"))
 
         shouldThrow<IllegalArgumentException> {
             testableHasColumnsInstance["bar"]
@@ -40,7 +40,7 @@ class HasColumnsTest {
 
     @Test
     fun `get operator returns Column expression for property`() {
-        whenever(testableHasColumnsInstance.columnNames).thenReturn(listOf(Something::prop.name))
+        whenever(testableHasColumnsInstance.selectableColumnNames).thenReturn(listOf(Something::prop.name))
 
         val column = testableHasColumnsInstance[Something::prop]
 

--- a/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/objects/TableTest.kt
+++ b/kraftsql/src/test/kotlin/rocks/frieler/kraftsql/objects/TableTest.kt
@@ -23,6 +23,11 @@ class TableTest {
     }
 
     @Test
+    fun `selectableColumnNames offers all columns`() {
+        table.selectableColumnNames shouldBe table.columnNames
+    }
+
+    @Test
     fun `get operator provides existing column by name`() {
         val column = table["c1"]
 


### PR DESCRIPTION
This is handled differently by every SQL engine. Hence, `Expression.defaultColumnName()` got removed and its behavior pushed into the h2 simulator. At the same time the `GenericQueryEvaluator` received a new extension point to implement the actual behavior of the simulated SQL engine.